### PR TITLE
Adds S3 persistence

### DIFF
--- a/rest-api/Dockerfile
+++ b/rest-api/Dockerfile
@@ -1,6 +1,11 @@
 FROM rook/toolbox:master
 MAINTAINER Steve Sloka <steves@heptio.com>
 
+RUN apt update \
+    && apt upgrade -y \
+    && apt install python python-dev python-pip -y \
+    && pip install awscli
+
 ADD _output/bin/rook-api /rook-api
 ADD toolbox.sh /usr/local/bin/toolbox.sh
 

--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -20,53 +20,92 @@ var (
 	argListenPort = flag.Int("listen-port", 9080, "port to have API listen")
 )
 
-// (POST "/block/{pool}/{snapid}/{imagename}")
+// /block/eu-west-2/fbn-prod-k8s-backup-primary/pvcs/0b3f70b1-f7fd-4c07-a5d2-7eb107d26fa3/replicapool/pvc-faacb401-4f9b-11e8-b3de-0a7763bb1b08
+// (POST "/block/{region}/{bucket}/{prefix}/{snapid}/{pool}/{imagename}")
 func createBlockRoute(w http.ResponseWriter, r *http.Request) {
+	initRook()
+
 	vars := mux.Vars(r)
 	poolName := vars["pool"]
 	snapid := vars["snapid"]
-	imagename := vars["imagename"]
+	imageName := vars["imagename"]
+	region := vars["region"]
+	bucket := vars["bucket"]
+	prefix := vars["prefix"]
 
-	err := copyVolumes(poolName, snapid, imagename)
+	fmt.Printf("poolname: %v\nsnapshotname: %v\nimageName: %v\nregion: %v \nbucket: %v\nprefix: %v\n", poolName, snapid, imageName, region, bucket, prefix)
 
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(os.Stderr, "There was an error creating the volume: ", err)
+	backupfile := fmt.Sprintf("/tmp/backup/%s/%s/%s", snapid, poolName, imageName)
+
+	// $ aws cp s3://{bucket}/{prefix}/{snap-name}/{pool-name} /tmp/backup/{snapid}/{pool}/{imagename} --sse --region {region}
+	cmd := "aws"
+	args := []string{"s3", "cp", fmt.Sprintf("s3://%s/%s/%s/%s/%s", bucket, prefix, snapid, poolName, imageName), backupfile, "--sse"}
+	fmt.Printf("%s %v\n", cmd, args)
+
+	if out, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+		fmt.Fprintln(os.Stderr, "There was an error creating the volume (aws): ", err)
+		fmt.Fprintln(os.Stderr, "command output: ", string(out))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// $ rbd import /tmp/backup/{snapshotName}/{pool}/{image} {pool}/{image} --export-format 2
+	// , "--image-feature", "layering"
+	cmd = "rbd"
+	args = []string{"import", "--export-format", "2", backupfile, fmt.Sprintf("%s/%s", poolName, imageName)}
+	fmt.Printf("%s %v\n", cmd, args)
+
+	if out, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+		fmt.Fprintln(os.Stderr, "There was an error creating the volume (rbd): ", err)
+		fmt.Fprintln(os.Stderr, "command output: ", string(out))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
-// (POST "/snapshot/{pool}/{snapname}/{imagename}")
+// (POST "/snapshot/{region}/{bucket}/{prefix}/{snapname}/{pool}/{imagename}")
 func createSnapshotRoute(w http.ResponseWriter, r *http.Request) {
+	initRook()
+
 	vars := mux.Vars(r)
 	poolName := vars["pool"]
 	snapshotName := vars["snapname"]
 	imageName := vars["imagename"]
+	region := vars["region"]
+	bucket := vars["bucket"]
+	prefix := vars["prefix"]
 
-	err := copyVolumes(poolName, imageName, snapshotName)
+	fmt.Printf("poolname: %v\nsnapshotname: %v\nimageName: %v\nregion: %v \nbucket: %v\nprefix: %v\n", poolName, snapshotName, imageName, region, bucket, prefix)
 
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(os.Stderr, "There was an error creating snapshot: ", err)
-	}
+	os.MkdirAll(fmt.Sprintf("/tmp/backup/%s/%s", snapshotName, poolName), os.FileMode(0522))
 
-}
-
-// copyVolumes copies one ceph volume to another
-func copyVolumes(poolName, sourceImage, destImage string) error {
-	initRook()
-
-	// $ rbd cp {pool}/{image} {pool}/{image}
+	backupfile := fmt.Sprintf("/tmp/backup/%s/%s/%s", snapshotName, poolName, imageName)
+	// $ rbd export {pool}/{image} /tmp/backup/{snapshotName}/{pool}/{image}
 	cmd := "rbd"
-	args := []string{"cp", fmt.Sprintf("%s/%s", poolName, sourceImage), fmt.Sprintf("%s/%s", poolName, destImage)}
+	args := []string{"export", "--export-format", "2", fmt.Sprintf("%s/%s", poolName, imageName), backupfile}
 
-	if _, err := exec.Command(cmd, args...).Output(); err != nil {
-		return err
+	fmt.Printf("%s %v\n", cmd, args)
+
+	if out, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+		fmt.Fprintln(os.Stderr, "There was an error creating snapshot (rbd): ", err)
+		fmt.Fprintln(os.Stderr, "command output: ", string(out))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
-	return nil
+	// $ aws mv {backupfile} s3://{bucket}/{prefix}/{pool-name}/{snap-name}/{imageNmae} --sse --region {region}
+	cmd = "aws"
+	args = []string{"s3", "mv", backupfile, fmt.Sprintf("s3://%s/%s/%s/%s/%s", bucket, prefix, snapshotName, poolName, imageName), "--sse"}
+	fmt.Printf("%s %v\n", cmd, args)
+
+	if out, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
+		fmt.Fprintln(os.Stderr, "There was an error creating snapshot (aws): ", err)
+		fmt.Fprintln(os.Stderr, "command output: ", string(out))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
-// (DELETE "/snapshot/{pool}/{snapname}")
+// (DELETE "/snapshot/{region}/{bucket}/{prefix}/{pool}/{snapname}")
 func deleteSnapshotRoute(w http.ResponseWriter, r *http.Request) {
 
 	initRook()
@@ -74,19 +113,25 @@ func deleteSnapshotRoute(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	poolName := vars["pool"]
 	snapshotName := vars["snapname"]
+	region := vars["region"]
+	bucket := vars["bucket"]
+	prefix := vars["prefix"]
 
-	// $ rbd --pool {pool-name} snap rm --snap {snap-name} {image-name}
-	cmd := "rbd"
-	args := []string{"rm", snapshotName, "-p", poolName}
+	fmt.Printf("poolname: %v\nsnapshotname: %v\nregion: %v \nbucket: %v\nprefix: %v\n", poolName, snapshotName, region, bucket, prefix)
+
+	// $ aws s3 rm s3://{bucket}/{prefix}/{snap-name}/{pool-name} --sse --region {region}
+	cmd := "aws"
+	args := []string{"s3", "rm", fmt.Sprintf("s3://%s/%s/%s/%s", bucket, prefix, snapshotName, poolName), "--sse"}
+	fmt.Printf("%s %v\n", cmd, args)
 	if err := exec.Command(cmd, args...).Run(); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		fmt.Println("Successfully deleted snapshot")
 	}
 }
 
-// (GET "/snapshot/{pool}/{imagename}")
+// (GET "/snapshot/{region}/{bucket}/{prefix}/{pool}/{imagename}")
 func listSnapshotsRoute(w http.ResponseWriter, r *http.Request) {
 
 	initRook()
@@ -94,26 +139,26 @@ func listSnapshotsRoute(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	poolName := vars["pool"]
 	imageName := vars["imagename"]
+	// region := vars["region"]
+	bucket := vars["bucket"]
+	prefix := vars["prefix"]
 
-	conn, _ := rados.NewConn()
-	conn.ReadDefaultConfigFile()
-	conn.Connect()
-	context, _ := conn.OpenIOContext(poolName)
-
-	image := rbd.GetImage(context, imageName)
-	snaps, err := image.GetSnapshotNames()
-
+	cmd := "aws"
+	args := []string{"s3", "ls", fmt.Sprintf("s3://%s/%s/%s/%s", bucket, prefix, poolName, imageName), "--sse"}
+	fmt.Printf("%s %v\n", cmd, args)
+	out, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
-		return
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		fmt.Println("Successfully listed snapshots")
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(snaps); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+	if err := json.NewEncoder(w).Encode(out); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
@@ -131,8 +176,8 @@ func getBlockRoute(w http.ResponseWriter, r *http.Request) {
 	context, err := conn.OpenIOContext(poolName)
 
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -141,8 +186,8 @@ func getBlockRoute(w http.ResponseWriter, r *http.Request) {
 	size, err := image.GetSize()
 
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -150,8 +195,8 @@ func getBlockRoute(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	if err := json.NewEncoder(w).Encode(size); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
@@ -169,24 +214,24 @@ func listBlocksRoute(w http.ResponseWriter, r *http.Request) {
 	context, err := conn.OpenIOContext(poolName)
 
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	names, err := rbd.GetImageNames(context)
 
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(names); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(os.Stderr, err)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 
 }
@@ -200,7 +245,7 @@ func initRook() {
 
 	cmd := "/usr/local/bin/toolbox.sh"
 	args := []string{}
-	if cmdOut, err = exec.Command(cmd, args...).Output(); err != nil {
+	if cmdOut, err = exec.Command(cmd, args...).CombinedOutput(); err != nil {
 		fmt.Fprintln(os.Stderr, "There was an error init'ing the toolbox: ", string(cmdOut))
 	} else {
 		log.Println("Called initRook()")
@@ -219,10 +264,10 @@ func main() {
 	// Configure router
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/", indexRoute)
-	router.HandleFunc("/block/{pool}/{snapid}/{imagename}", createBlockRoute).Methods("POST")
-	router.HandleFunc("/snapshot/{pool}/{snapname}/{imagename}", createSnapshotRoute).Methods("POST")
-	router.HandleFunc("/snapshot/{pool}/{snapname}", deleteSnapshotRoute).Methods("DELETE")
-	router.HandleFunc("/snapshot/{pool}/{imagename}", listSnapshotsRoute).Methods("GET")
+	router.HandleFunc("/block/{region}/{bucket}/{prefix}/{snapid}/{pool}/{imagename}", createBlockRoute).Methods("POST")
+	router.HandleFunc("/snapshot/{region}/{bucket}/{prefix}/{snapname}/{pool}/{imagename}", createSnapshotRoute).Methods("POST")
+	router.HandleFunc("/snapshot/{region}/{bucket}/{prefix}/{snapname}/{pool}", deleteSnapshotRoute).Methods("DELETE")
+	router.HandleFunc("/snapshot/{region}/{bucket}/{prefix}/{pool}/{imagename}", listSnapshotsRoute).Methods("GET")
 	router.HandleFunc("/block/{pool}", listBlocksRoute).Methods("GET")
 	router.HandleFunc("/block/{pool}/{imagename}", getBlockRoute).Methods("GET")
 


### PR DESCRIPTION
This is achieved by:
* using `rbd export/import`
* includes aws cli in the docker image
* during backup, moves the `rbd export` file to the configured s3 bucket with prefix
* during restore, copies the file from the s3 location to disk before performing an `rbd import`

Notes:
* it doesn't like restoring to a cluster that already has the volumes
  I discovered that quite a bit during development.  Not sure how much of
  a problem it will be under normal operation.
* Additional config needs to be supplied.